### PR TITLE
docs: removed zb section from Monitoring article

### DIFF
--- a/docs/articles/monitoring.md
+++ b/docs/articles/monitoring.md
@@ -116,22 +116,3 @@ The configuration file of zxp contains connection details for the zot server fro
 > The zxp module does not have Prometheus integration.
 >
 > The zxp module is not needed with a full zot image.
-
-
-
-## Benchmarking zot with zb
-
-The [zot project](https://github.com/project-zot/zot) includes the `zb` tool, which allows you to benchmark a zot registry or any other container image registry that conforms to the [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec) published by the Open Container Initiative (OCI).
-
-The `zb` tool is useful for benchmarking zot registry workloads in
-scenarios such as the following:
-
--   comparing configuration changes
-
--   comparing software versions
-
--   comparing hardware/deployment environments
-
--   comparing with other registries
-
-For detailed information about benchmarking with `zb`, see [Benchmarking zot with zb](../articles/benchmarking-with-zb.md).

--- a/docs/articles/monitoring.md
+++ b/docs/articles/monitoring.md
@@ -2,6 +2,8 @@
 
 > :point_right: **zot** supports a range of monitoring tools including logging, metrics, and benchmarking.
 
+The following sections describe how to configure logging and monitoring with zot. You can use zot's benchmarking tool to test your configuration and deployment, as described in [Benchmarking zot with zb](benchmarking-with-zb.md).
+
 ## Logging
 
 Logging for zot operations is configured with the `log` attribute in the configuration file, as shown in the following example.


### PR DESCRIPTION
**What type of PR is this?**

documentation

**Which issue does this PR fix**:

none

**What does this PR do / Why do we need it**:

removes benchmarking section from Monitoring article because there is already a separate Benchmarking article

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
