### PR TITLE
docs: fix versioning in documentation with mkdocs-macros

### DIFF
--- a/docs/install-guides/install-guide-k8s.md
+++ b/docs/install-guides/install-guide-k8s.md
@@ -36,7 +36,7 @@ image variations, image locations, and image naming formats.
     Give the repo a local name, such as **project-zot**, as in this
     example:
 
-    `$ helm repo add project-zot http://zotregistry.io/helm-charts`
+    `helm repo add project-zot http://zotregistry.io/helm-charts`
 
         "project-zot" has been added to your repositories
 
@@ -51,10 +51,10 @@ image variations, image locations, and image naming formats.
 2.  Search the repository to see the Helm charts for zot installation.
     Search using the keyword 'project-zot' or 'zot', as in this example:
 
-    `$ helm search repo project-zot`
+    `helm search repo project-zot`
 
         NAME             CHART VERSION  APP VERSION  DESCRIPTION
-        project-zot/zot  0.1.0          v1.4.3       A Helm chart for Kubernetes
+        project-zot/zot  <chart-version>          {{ git.tag }}       A Helm chart for Kubernetes
 
 
     > :pencil2:
@@ -65,7 +65,7 @@ image variations, image locations, and image naming formats.
 3.  Update to the latest information of available charts from the chart
     repository, as shown in this example:
 
-    `$ helm repo update project-zot`
+    `helm repo update project-zot`
 
         Hang tight while we grab the latest from your chart repositories...
         ...Successfully got an update from the "project-zot" chart repository
@@ -74,15 +74,15 @@ image variations, image locations, and image naming formats.
 4.  Display the default information of the Helm chart, as shown in this
     example:
 
-`$ helm show all project-zot/zot`
+`helm show all project-zot/zot`
 
 ``` yaml
     apiVersion: v2
-    appVersion: v1.4.3
+    appVersion: {{ git.tag }}
     description: A Helm chart for Kubernetes
     name: zot
     type: application
-    version: 0.1.16
+    version: <chart-version>
 
     # Default values for zot.
     # This is a YAML-formatted file.
@@ -91,7 +91,7 @@ image variations, image locations, and image naming formats.
     image:
       repository: ghcr.io/project-zot/zot-linux-amd64
       pullPolicy: IfNotPresent
-      tag: "v1.4.3"
+      tag: "{{ git.tag }}"
     serviceAccount:
       create: true
       annotations: {}
@@ -110,7 +110,7 @@ may be able to specify them during the installation. Not all chart
 values are configurable, but you can display those that are configurable
 using the command in the following example:
 
-`$ helm show values project-zot/zot`
+`helm show values project-zot/zot`
 
 ``` yaml
   # Default values for zot.
@@ -120,7 +120,7 @@ using the command in the following example:
   image:
     repository: ghcr.io/project-zot/zot-linux-amd64
     pullPolicy: IfNotPresent
-    tag: "v1.4.3"
+    tag: "{{ git.tag }}"
   serviceAccount:
     create: true
     annotations: {}
@@ -172,7 +172,7 @@ repository. If not specified, the policy depends on
 <td style="text-align: left;"><p>Identifies different versions the
 image. default is the chart <code>appVersion</code>.</p>
 <p>Examples: <code>:latest</code> (the default) or
-<code>:v1.4.3</code></p></td>
+<code>:{{ git.tag }}</code></p></td>
 </tr>
 <tr class="odd">
 <td style="text-align: left;"><p>serviceAccount.create</p></td>
@@ -251,7 +251,7 @@ settings in the Helm chart:
 
 **Example 1: use default chart parameters**
 
-`$ helm install zot project-zot/zot`
+`helm install zot project-zot/zot`
 
     NAME: zot
     LAST DEPLOYED: Thu Aug 11 19:13:02 2022
@@ -267,23 +267,23 @@ settings in the Helm chart:
 
 **Example 2: modify specific chart parameters with 'set'**
 
-`$ helm install --set replicaCount=2,service.port=5050 zot project-zot/zot`
+`helm install --set replicaCount=2,service.port=5050 zot project-zot/zot`
 
 
 **Example 3: modify specific chart parameters with a file**
 
 
-`$ helm install -f myfile.yaml zot project-zot/zot`
+`helm install -f myfile.yaml zot project-zot/zot`
 
 
 **Example 4: use a specific version of the Helm chart**
 
-`$ helm install zot project-zot/zot --version 0.1.0`
+`helm install zot project-zot/zot --version 0.1.0`
 
 
 **Example 5: link to a kubeconfig file**
 
-`$ helm install zot project-zot/zot --kubeconfig $HOME/.kube/config`
+`helm install zot project-zot/zot --kubeconfig $HOME/.kube/config`
 
 ## After the installation
 
@@ -291,10 +291,10 @@ settings in the Helm chart:
 
 1.  List all releases that are either deployed or failed.
 
-    `$ helm list`
+    `helm list`
 
         NAME  NAMESPACE  REVISION  UPDATED    STATUS    CHART      APP VERSION
-        zot   default    1         <datetime> deployed  zot-0.1.0  v1.4.3
+        zot   default    1         <datetime> deployed  <chart-version>  {{ git.tag }}
 
     This response indicates that zot is deployed.
 
@@ -362,4 +362,4 @@ Refer to [*Configuring zot*](../admin-guide/admin-configuration.md) for complete
 Should you need to uninstall zot, use the `helm uninstall` command, as
 in this example:
 
-`$ helm uninstall zot`
+`helm uninstall zot`

--- a/docs/install-guides/install-guide-linux.md
+++ b/docs/install-guides/install-guide-linux.md
@@ -23,7 +23,7 @@ project](https://github.com/project-zot/zot/releases). Download the
 image to the\`/usr/bin/\` directory and rename it to `zot,` as in this
 example:
 
-    $ wget -O /usr/bin/zot  https://github.com/project-zot/zot/releases/download/v1.4.2-rc2/zot-linux-amd64
+    wget -O /usr/bin/zot  https://github.com/project-zot/zot/releases/download/{{ git.tag }}/zot-linux-amd64
 
 ### Step 2: Create a zot configuration file
 
@@ -40,11 +40,11 @@ If you want to use local authentication with zot, create a
 `/etc/zot/htpasswd` file with an initial account entry using the
 `htpasswd` command as in this example:
 
-    $ htpasswd -bnB myUserName myPassword > /etc/zot/htpasswd
+    htpasswd -bnB myUserName myPassword > /etc/zot/htpasswd
 
 To add additional local users, use the `>>` redirect as in this example:
 
-    $ htpasswd -bnB myUserName2 myPassword2 >> /etc/zot/htpasswd
+    htpasswd -bnB myUserName2 myPassword2 >> /etc/zot/htpasswd
 
 ### Step 4: Define the zot service
 
@@ -78,16 +78,16 @@ Create a non-root user ID to be the owner of the zot service and its resources.
 
 In this example, the user ID 'zot' is created with the `adduser` command, and resource ownership is assigned.
 
-    $ sudo adduser --no-create-home --disabled-password --gecos --disabled-login zot
+    sudo adduser --no-create-home --disabled-password --gecos --disabled-login zot
 
-    $ sudo mkdir -p /data/zot
-    $ sudo chown -R zot:zot /data/zot
+    sudo mkdir -p /data/zot
+    sudo chown -R zot:zot /data/zot
 
-    $ sudo mkdir -p /var/log/zot
-    $ sudo chown -R zot:zot /var/log/zot
+    sudo mkdir -p /var/log/zot
+    sudo chown -R zot:zot /var/log/zot
 
-    $ sudo chown root:root /usr/bin/zot
-    $ sudo chown root:root config.json
+    sudo chown root:root /usr/bin/zot
+    sudo chown root:root config.json
 
 With the `adduser` options shown, the 'zot' user ID has no local
 directory. There is no ability to log into the zot user account, and the
@@ -97,13 +97,13 @@ account has no finger information.
 
 Enable and start the zot service with these commands:
 
-    $ sudo systemctl enable zot
-    $ sudo systemctl start zot
+    sudo systemctl enable zot
+    sudo systemctl start zot
 
 When the zot service has started, you can check its status with this
 command:
 
-    $ sudo systemctl status zot
+    sudo systemctl status zot
 
 ## After the installation
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ plugins:
   - minify:
       minify_html: true
   - git-revision-date-localized
+  - macros
 markdown_extensions:
   - abbr
   - admonition

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mkdocs-minify-plugin==0.6.2
 mike==1.1.2
 markdown-include==0.7.0
 mkdocs-git-revision-date-localized-plugin==1.1.0
+mkdocs-macros-plugin==0.7.0


### PR DESCRIPTION
Track versioning info in documentation using mkdocs-macros so this happens automatically.

Originally reported by @imjasonh:
https://github.com/project-zot/project-zot.github.io/pull/80


(cherry picked from commit e87d28307905b546dc186fc142c97de159f143f0)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
