### PR TITLE
docs: add note about bcrypt for htpasswd

### DIFF
--- a/docs/articles/authn-authz.md
+++ b/docs/articles/authn-authz.md
@@ -4,9 +4,9 @@
 >
 > -   Authentication
 >
->    -   TLS, including mTLS
->    -   Username/password or token-based user authentication
->    -   LDAP
+>     -   TLS, including mTLS
+>     -   Username/password or token-based user authentication
+>     -   LDAP
 >     -   htpasswd
 > 
 > -   Authorization
@@ -151,6 +151,8 @@ configuration file, as shown in the following example.
 1.  Create and store an `htpasswd` file on the server.
 
         $ htpasswd -bBn <username> <password> >> /etc/zot/htpasswd
+
+    :pencil2: For strong security, make sure to use the -B option, specifying the bcrypt hashing algorithm. This is the only algorithm supported by zot for `htpasswd`.
 
 2.  Enable `htpasswd` authentication and configure the path to the
     `htpasswd` authentication in the zot configuration file.


### PR DESCRIPTION
**What type of PR is this?**

documentation

**What does this PR do / Why do we need it**:

For v1.4, explains that bcrypt is hashing function for htpasswd
Similar to PR #106 for v2.0.0


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
