### PR TITLE
docs: add group policies for user auth (replaces 109)

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -56,6 +56,9 @@ gc
 gcr
 ghcr
 github
+GitHub
+gitlab
+GitLab
 golang
 GPG
 graphQL
@@ -103,6 +106,7 @@ natively
 NodePort
 OAuth
 OCI
+OIDC
 onboarding
 Onboarding
 onDemand

--- a/docs/articles/authn-authz.md
+++ b/docs/articles/authn-authz.md
@@ -138,8 +138,8 @@ authentication.
 | `port`          | The port number used by the LDAP service.                                        |
 | `startTLS`      | Set to `true` to enable TLS communication with the LDAP server.                  |
 | `baseDN`        | Starting location within the LDAP directory for performing user searches.        |
-| `userAttribute` | Attribute name used for a user.                                                  |
-| `userGroupAttribute` | Attribute name used for a group.                                            |
+| `userAttribute` | Attribute name used to obtain the username.                                                  |
+| `userGroupAttribute` | Attribute name used to obtain groups to which a user belongs.                                            |
 | `bindDN`        | Base Distinguished Name for the LDAP search.                                     |
 | `bindPassword`  | Password of the bind LDAP user.                                                  |
 | `skipVerify`    | Skip TLS verification.                                                           |


### PR DESCRIPTION
**What type of PR is this?**

documentation

**What does this PR do / Why do we need it**:

Adds ability to define groups for authz policies
This PR supersedes previous PR https://github.com/project-zot/project-zot.github.io/pull/109


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
