### PR TITLE
correct the callback url

### DIFF
--- a/docs/articles/authn-authz.md
+++ b/docs/articles/authn-authz.md
@@ -367,11 +367,11 @@ For example, a user logging in to the zot home page using GitHub as the authenti
 
 Based on the specified provider, zot redirects the login to a provider service with the following URL:
 
-    http://<zot-server>/auth/callback/<provider>
+    http://<zot-server>/zot/auth/callback/<provider>
 
 For the GitHub authentication example:
 
-    http://zot.example.com:8080/auth/callback/github
+    http://zot.example.com:8080/zot/auth/callback/github
 
 :pencil2: If your network policy doesn't allow inbound connections, the callback will not work and this authentication method will fail.
 
@@ -385,7 +385,7 @@ Like zot, dex uses a configuration file for setup. To specify zot as a client in
 staticClients:
   - id: zot-client
     redirectURIs:
-      - 'http://zot.example.com:8080/auth/callback/oidc'
+      - 'http://zot.example.com:8080/zot/auth/callback/oidc'
     name: 'zot'
     secret: ZXhhbXBsZS1hcHAtc2VjcmV0
 ```


### PR DESCRIPTION
Fix for https://github.com/project-zot/zot/issues/2191

Callback URL syntax path is incorrect, misses the `zot/`.  Correct path is given in: https://github.com/project-zot/zot/blob/9def35f3b8b38f5a438146a09087edcec00537c7/examples/README.md?plain=1#L294

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

documentation

**Which issue does this PR fix**:

Fix for https://github.com/project-zot/zot/issues/2191


**What does this PR do / Why do we need it**:

Callback URL is incorrect in docs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
