### PR TITLE
fix: replace repoNames with repositories in docs/articles/retention.md

### DIFF
--- a/docs/articles/retention.md
+++ b/docs/articles/retention.md
@@ -37,7 +37,7 @@ _simple policy example_
       "delay": "24h",
       "policies": [
         {
-          "repoNames": ["infra/*", "tmp/**"],
+          "repositories": ["infra/*", "tmp/**"],
           "deleteReferrers": false,
           "deleteUntagged": true,
           "keepTags": [{


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
