### PR TITLE
Remove the usage of "-X POST"

### DIFF
--- a/docs/articles/verifying-signatures.md
+++ b/docs/articles/verifying-signatures.md
@@ -48,7 +48,7 @@ Upload these files using an extension of the zot API, as shown in the following 
     ```
     *Example request*
     ```
-    curl --data-binary @file.pub -X POST "http://localhost:8080/v2/_zot/ext/cosign"
+    curl --data-binary @file.pub "http://localhost:8080/v2/_zot/ext/cosign"
     ```
     *Result*
 
@@ -65,7 +65,7 @@ Upload these files using an extension of the zot API, as shown in the following 
 
     *Example request*
     ```
-    curl --data-binary @certificate.crt -X POST "http://localhost:8080/v2/_zot/ext/notation?truststoreType=ca"
+    curl --data-binary @certificate.crt "http://localhost:8080/v2/_zot/ext/notation?truststoreType=ca"
     ```
     *Result*
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

documentation

**Which issue does this PR fix**:

`-X POST` is not necessary due to the use of `--data-binary`.

There are additional details in https://daniel.haxx.se/blog/2015/09/11/unnecessary-use-of-curl-x/ on why this is misleading and potentially harmful for new users.

**What does this PR do / Why do we need it**:

It corrects the curl command to be what the curl author intents to be used instead of the often seen usage of `-X`

**If an issue # is not available please add repro steps and logs showing the issue**:

N/A

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

Both commands are functionally equal when executing.

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

Not that I can think of.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
