### PR TITLE
docs: fill gaps in the v2.1.19 release notes coverage

### DIFF
--- a/docs/articles/graphql.md
+++ b/docs/articles/graphql.md
@@ -738,6 +738,7 @@ This query returns an `ImageSummary` for a specific `<repo>:<tag>` reference and
     Tag
     Digest
     MediaType
+    ArtifactType
     Size
     DownloadCount
     LastPullTimestamp
@@ -844,6 +845,7 @@ This query returns an `ImageSummary` for a specific `<repo>:<tag>` reference and
 - **`Tag`**: Tag requested.
 - **`Digest`**: Content digest of the resolved image manifest or index.
 - **`MediaType`**: Media type of the resolved object (for example, manifest vs index).
+- **`ArtifactType`**: For image manifests, the OCI `artifactType` when present, otherwise the config media type. For image indexes, the index `artifactType` when present. This is the top-level `ImageSummary` field; per-platform values are also available under `Manifests`.
 
 **Sizes and popularity**
 
@@ -902,6 +904,7 @@ This query returns an `ImageSummary` for a specific `<repo>:<tag>` reference and
       "Tag": "latest",
       "Digest": "sha256:85f2b723e106c34644cd5851d7e81ee87da98ac54672b29947c052a45d31dc2f",
       "MediaType": "application/vnd.oci.image.manifest.v1+json",
+      "ArtifactType": "application/vnd.oci.image.config.v1+json",
       "Size": "3804055",
       "DownloadCount": 0,
       "LastPullTimestamp": "1970-01-01T00:00:00Z",

--- a/docs/articles/storage.md
+++ b/docs/articles/storage.md
@@ -170,6 +170,16 @@ there is no periodic collection. Requires the <code>gc</code> attribute
 to be <code>true</code>.</p></td>
 </tr>
 <tr class="odd">
+<td style="text-align: left;"><p><code>gcTimeWindow</code></p></td>
+<td style="text-align: left;"><p>(Optional) Restricts when periodic GC
+sweeps may start to a daily UTC <code>HH:MM-HH:MM</code> window (start
+inclusive, end exclusive; may cross midnight). Applies only when
+periodic GC is enabled (<code>gcInterval</code> greater than zero).
+Once a sweep starts inside the window, it runs to completion even if the
+window ends. Changes require a zot restart. Available for the top-level
+storage configuration and individual subpaths.</p></td>
+</tr>
+<tr class="even">
 <td style="text-align: left;"><p><code>subpaths</code></p></td>
 <td style="text-align: left;"><p>You can store and serve images from
 multiple filesystems, each with their own repository paths and settings.
@@ -193,15 +203,15 @@ class="sourceCode json"><code class="sourceCode json"><span id="cb1-1"><a href="
 <span id="cb1-16"><a href="#cb1-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
 <span id="cb1-17"><a href="#cb1-17" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div></td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td style="text-align: left;"><p><code>storageDriver</code></p></td>
 <td style="text-align: left;"><p>(Remote storage only) Contains settings for a remote storage service. See <a href="#config-s3"><i>Configuring remote storage with s3</i></a>, <a href="#config-gcs"><i>Configuring remote storage with GCS</i></a>, and <a href="#config-azure"><i>Configuring remote storage with Azure Blob Storage</i></a> for details.</p></td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td style="text-align: left;"><p><code>fastRestart</code></p></td>
 <td style="text-align: left;"><p>(Optional) When set to <code>true</code>, zot can skip the startup storage walk if an internal fast-restart stamp matches the running binary identity and storage configuration. This can significantly reduce restart times for large registries. Trade-off: out-of-band storage changes made while zot is down will not be discovered at startup when the walk is skipped. The default is <code>false</code>.</p></td>
 </tr>
-<tr class="even">
+<tr class="odd">
 <td style="text-align: left;"><p><code>redirectBlobURL</code></p></td>
 <td style="text-align: left;"><p>(Optional, remote storage) When set to <code>true</code>, blob pull requests can be redirected (HTTP 307) to signed backend URLs from the configured storage driver, reducing proxy traffic through zot. If URL generation is unavailable or invalid, zot falls back to normal proxying. Can be configured globally and per-subpath.</p></td>
 </tr>
@@ -226,6 +236,8 @@ The zot configuration model allows for enabling and disabling garbage collection
 | true      | omitted      | GC enabled with 1 hour interval |
 | true      |  0           | GC runs only once |
 | true      |  >0          | GC enabled with specified interval |
+
+Optional `gcTimeWindow` further restricts when those periodic sweeps may *start*. It has no effect when GC is disabled or when `gcInterval` is `0`.
 
 The configuration model also allows the configuration of a tunable delay (`gcDelay`), which can be set depending on client network speeds and the size of blobs. The `gcDelay` attribute causes collection to run once after the specified delay time.  This attribute has a default value of one hour (`1h`).
 

--- a/docs/general/whats-new.md
+++ b/docs/general/whats-new.md
@@ -28,7 +28,12 @@ See [Verifying image signatures](../articles/verifying-signatures.md), [CVE scan
 
 ### Reliability, Conformance, and Security Fixes
 
-This release improves OCI conformance for malformed manifest references, referrers responses, and blob digest errors. It also fixes digest multi-tag overwrite authorization, cosign verification binding, garbage collection of incomplete content, storage integrity checks, sync diagnostics and credential refresh, Windows repository paths, and metadata robustness.
+- Hardened the OIDC UI callback redirect against open redirects that used a backslash in the target URL.
+- Sync registries can set `maxRetryDelay` for exponential HTTP retry backoff (when greater than `retryDelay`).
+- Improved OCI conformance for malformed manifest references, referrers responses, and blob digest errors.
+- Additional fixes cover digest multi-tag overwrite authorization, cosign verification binding, garbage collection of incomplete content, storage integrity checks, sync diagnostics and credential refresh, Windows repository paths, and metadata robustness.
+
+See [OCI registry mirroring](../articles/mirroring.md) and [Events](../articles/events.md).
 
 ## [v2.1.18](https://github.com/project-zot/zot/releases/tag/v2.1.18)
 


### PR DESCRIPTION
Document top-level GraphQL ImageSummary.ArtifactType, add gcTimeWindow to the storage config tables, and call out the OIDC open-redirect fix, maxRetryDelay in What's New.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
